### PR TITLE
Screamingvortex/improve grid smoothing

### DIFF
--- a/screamingvortex/grid/Sector_test.go
+++ b/screamingvortex/grid/Sector_test.go
@@ -41,6 +41,10 @@ func TestSectorRandomize(t *testing.T) {
           t.Errorf("Route is connected to system outside the main label. TargetSystem: %v", route.TargetSystem())
         }
       }
+
+      if system.RegionId == int64(system.TheUnsetLabel()) {
+        t.Errorf("Grid System {%d, %d} has not been properly given a RegionId.", system.X, system.Y)
+      }
     }
   }
 

--- a/screamingvortex/grid/System.go
+++ b/screamingvortex/grid/System.go
@@ -39,7 +39,7 @@ func (system *System) LabelIsUnset() bool {
 }
 
 func (system *System) InitializeAt(i int, j int) {
-  system.RegionId = 1
+  system.RegionId = int64(system.TheUnsetLabel())
 
   system.X = i
   system.Y = j

--- a/screamingvortex/grid/System.go
+++ b/screamingvortex/grid/System.go
@@ -8,6 +8,7 @@ type System struct {
   RegionId int64 `sql:"region_id"`
   Routes []*Route
   blobLabel int
+  systemIndex int
 }
 
 func (system *System) TableName(systemType string) string {


### PR DESCRIPTION
Add alternate smoothing algorithm to Grid generation. If a smoothing factor of 1.0 or greater is specified, the smoothing factor will be reduced by 1.0 and the initial state of the Grid (before smoothing) will be blobs of regions instead of a fuzzy static.